### PR TITLE
feat: add monitoring threshold job

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -110,5 +110,10 @@
             <argument>%resque_alert_from%</argument>
             <argument>%resque_alert_to%</argument>
         </service>
+
+        <service id="resque.service.job.monitoring.queue-threshold-alert" class="AllProgrammic\Bundle\ResqueBundle\Service\Monitoring\QueueThresholdAlertJob" public="true">
+            <argument type="service" id="resque"/>
+            <argument type="service" id="resque.service.mail_sender"/>
+        </service>
     </services>
 </container>

--- a/Resources/views/mails/monitoring/queue-threshold-alert/above.html.twig
+++ b/Resources/views/mails/monitoring/queue-threshold-alert/above.html.twig
@@ -1,0 +1,5 @@
+{% extends '@AllProgrammicResque/mails/base.html.twig' %}
+
+{% block content %}
+    <p>Message in queue <strong>{{ queue }}</strong> is above the threshold of {{ threshold }} with a value of {{ size }} </p>
+{% endblock %}

--- a/Resources/views/mails/monitoring/queue-threshold-alert/below.html.twig
+++ b/Resources/views/mails/monitoring/queue-threshold-alert/below.html.twig
@@ -1,0 +1,5 @@
+{% extends '@AllProgrammicResque/mails/base.html.twig' %}
+
+{% block content %}
+    <p>Message in queue <strong>{{ queue }}</strong> go back below the threshold of {{ threshold }} with a value of {{ size }} </p>
+{% endblock %}

--- a/Service/Monitoring/QueueThresholdAlertJob.php
+++ b/Service/Monitoring/QueueThresholdAlertJob.php
@@ -34,17 +34,17 @@ class QueueThresholdAlertJob extends AbstractJob
 
         foreach ($this->engine->queues() as $queue) {
             if (preg_match($options['queues'], $queue) && (empty($options['excludedQueues']) || !preg_match($options['excludedQueues'], $queue))) {
-                $alertStatus = $this->engine->getBackend()->get(static::class.':'.$queue);
+                $alertStatus = $this->engine->getBackend()->get('monitoring:'.static::class.':'.$queue);
                 $size = $this->engine->size($queue);
                 if (!$alertStatus && $size > $options['threshold']) {
-                    $this->engine->getBackend()->set(static::class.':'.$queue, (new \DateTimeImmutable())->format('c'));
+                    $this->engine->getBackend()->set('monitoring:'.static::class.':'.$queue, (new \DateTimeImmutable())->format('c'));
                     $this->mailSender->send('monitoring/queue-threshold-alert/above', [
                         'queue' => $queue,
                         'threshold' => $options['threshold'],
                         'size' => $size,
                     ]);
                 } else if ($alertStatus && $size <= $options['threshold']) {
-                    $this->engine->getBackend()->del(static::class.':'.$queue);
+                    $this->engine->getBackend()->del('monitoring:'.static::class.':'.$queue);
                     $this->mailSender->send('monitoring/queue-threshold-alert/below', [
                         'queue' => $queue,
                         'threshold' => $options['threshold'],

--- a/Service/Monitoring/QueueThresholdAlertJob.php
+++ b/Service/Monitoring/QueueThresholdAlertJob.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace AllProgrammic\Bundle\ResqueBundle\Service\Monitoring;
+
+
+use AllProgrammic\Bundle\ResqueBundle\Service\MailSender;
+use AllProgrammic\Component\Resque\AbstractJob;
+use AllProgrammic\Component\Resque\Engine;
+
+class QueueThresholdAlertJob extends AbstractJob
+{
+    /**
+     * @var Engine
+     */
+    private $engine;
+    /**
+     * @var MailSender
+     */
+    private $mailSender;
+
+    public function __construct(Engine $engine, MailSender $mailSender)
+    {
+        $this->engine = $engine;
+        $this->mailSender = $mailSender;
+    }
+
+    public function perform($args)
+    {
+        try {
+            $options = $this->normalizeOptions($args);
+        } catch (\Exception $e) {
+            throw new \RuntimeException("an invalid argument was passed to job", 0, $e);
+        }
+
+        foreach ($this->engine->queues() as $queue) {
+            if (preg_match($options['queues'], $queue) && !preg_match($options['excludedQueues'], $queue)) {
+                $alertStatus = $this->engine->getBackend()->get(static::class.':'.$queue);
+                $size = $this->engine->size($queue);
+                if (!$alertStatus && $size > $options['threshold']) {
+                    $this->engine->getBackend()->set(static::class.':'.$queue, (new \DateTimeImmutable())->format('c'));
+                    $this->mailSender->send('monitoring/queue-threshold-alert/above', [
+                        'queue' => $queue,
+                        'threshold' => $options['threshold'],
+                        'size' => $size,
+                    ]);
+                } else if ($alertStatus && $size <= $options['threshold']) {
+                    $this->engine->getBackend()->del(static::class.':'.$queue);
+                    $this->mailSender->send('monitoring/queue-threshold-alert/below', [
+                        'queue' => $queue,
+                        'threshold' => $options['threshold'],
+                        'size' => $size,
+                    ]);
+                }
+            }
+        }
+    }
+
+    /**
+     * @throws \Exception
+     */
+    protected function normalizeOptions($args)
+    {
+        $options = [
+            'queues' => '/.*/',
+            'excludedQueues' => null,
+            'threshold' => null,
+        ];
+
+        if (is_array($args)) {
+            if (isset($args['queues'])) {
+                $options['queues'] = $args['queues'];
+            }
+            if (isset($args['excludedQueues'])) {
+                $options['excludedQueues'] = $args['excludedQueues'];
+            }
+            if (isset($args['threshold'])) {
+                $options['threshold'] = filter_var($args['threshold'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'default' => null]]);
+            }
+        }
+
+        if (@preg_match($options['queues'], 'fake') === false) {
+            throw new \InvalidArgumentException(sprintf('Provided argument "queues: %s" must be a valid regex pattern with delimiter.', isset($args['queues']) ? $args['queues'] : null));
+        }
+
+        if (@preg_match($options['excludedQueues'], 'fake') === false) {
+            throw new \InvalidArgumentException(sprintf('Provided argument "excludedQueues: %s" must be a valid regex pattern with delimiter.', isset($args['excludedQueues']) ? $args['excludedQueues'] : null));
+        }
+
+        if (empty($options['threshold'])) {
+            throw new \InvalidArgumentException(sprintf('Provided argument "threshold: %s" must be defined as a positive integer.', isset($args['threshold']) ? $args['threshold'] : null));
+        }
+
+        return $options;
+    }
+}

--- a/Service/Monitoring/QueueThresholdAlertJob.php
+++ b/Service/Monitoring/QueueThresholdAlertJob.php
@@ -33,7 +33,7 @@ class QueueThresholdAlertJob extends AbstractJob
         }
 
         foreach ($this->engine->queues() as $queue) {
-            if (preg_match($options['queues'], $queue) && !preg_match($options['excludedQueues'], $queue)) {
+            if (preg_match($options['queues'], $queue) && (empty($options['excludedQueues']) || !preg_match($options['excludedQueues'], $queue))) {
                 $alertStatus = $this->engine->getBackend()->get(static::class.':'.$queue);
                 $size = $this->engine->size($queue);
                 if (!$alertStatus && $size > $options['threshold']) {
@@ -73,7 +73,7 @@ class QueueThresholdAlertJob extends AbstractJob
             if (isset($args['excludedQueues'])) {
                 $options['excludedQueues'] = $args['excludedQueues'];
             }
-            if (isset($args['threshold'])) {
+            if (isset($args['threshold']) && !empty($args['threshold'])) {
                 $options['threshold'] = filter_var($args['threshold'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'default' => null]]);
             }
         }
@@ -82,7 +82,7 @@ class QueueThresholdAlertJob extends AbstractJob
             throw new \InvalidArgumentException(sprintf('Provided argument "queues: %s" must be a valid regex pattern with delimiter.', isset($args['queues']) ? $args['queues'] : null));
         }
 
-        if (@preg_match($options['excludedQueues'], 'fake') === false) {
+        if (!empty($options['excludedQueues']) && @preg_match($options['excludedQueues'], 'fake') === false) {
             throw new \InvalidArgumentException(sprintf('Provided argument "excludedQueues: %s" must be a valid regex pattern with delimiter.', isset($args['excludedQueues']) ? $args['excludedQueues'] : null));
         }
 


### PR DESCRIPTION
fourni un job par défaut dans le bundle pour monitorer le nombre d'event dans les queues
il suffit de déclarer ce job en tant que recurring job
class : resque.service.job.monitoring.queue-threshold-alert
args: 
```
{
  "queues": "/pattern de queue à monitorer/",
  "excludedQueues": "/pattern optionel pour exclure des queues/",
  "threshold": 200
}
```

Pour que ça marche, il faudra :
- configurer resque dans tython pour l'envoi de mail
- déclarer la tâche récurrente dans resque (en utilisant la queue monitoring comme queue de cette tâche)
- ajouter un worker spécifique à la queue monitoring, que je pense faire tourner à côté des instances tython, donc configuration de supervisor
- modifier les templates d'instances des workers pour exclure la queue monitoring des worker std

(PI j'ai commencé à préparer tout ça)